### PR TITLE
limit the amount of time for jobs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,6 +25,8 @@ jobs:
   examples:
     name: Examples (Julia - ${{ matrix.version }})
     runs-on: ubuntu-latest
+    # Set maximum runtime for this job to 30 minutes
+    timeout-minutes: 30
     strategy:
       matrix:
         version:
@@ -56,6 +58,8 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
+    # Set maximum runtime for this job to 15 minutes
+    timeout-minutes: 15
     needs: examples
     permissions:
       contents: write


### PR DESCRIPTION
For some reason Julia 1.10 deadlocks itself when installing the packages, this limit would prevent this from running indefinitely and burning our CI minutes