### PR TITLE
fix: on make docs-serve, page was constantly refreshing. Now not.

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,7 +9,6 @@ struct Category
 end
 
 # Define category order (categories not in this list will be sorted alphabetically at the end)
-if !isdefined(@__MODULE__, :ORDERED_CATEGORIES)
 const ORDERED_CATEGORIES = [
     Category(
         "Basic Examples",
@@ -45,7 +44,6 @@ additional patches to RxInfer.jl to work.
 """
     )
 ]
-end
 
 const ALL_EXAMPLES_CONTRIBUTING_NOTE = """
 !!! note "Contributing"
@@ -180,7 +178,6 @@ const THEME_STYLES = """
 """
 
 # Default tags for all examples
-if !isdefined(@__MODULE__, :DEFAULT_META_TAGS)
 const DEFAULT_META_TAGS = [
     "rxinfer",
     "julia",
@@ -192,17 +189,14 @@ const DEFAULT_META_TAGS = [
     "variational inference",
     "belief propagation",
 ]
-end
 
 # Directories to ignore when processing HTML files
-if !isdefined(@__MODULE__, :IGNORED_DIRECTORIES)
 const IGNORED_DIRECTORIES = [
     "_cache",
     "_assets",
     "_internal",
     ".ipynb_checkpoints"
 ]
-end
 
 # Function to generate the list of examples page
 function generate_examples_list()

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,6 +9,7 @@ struct Category
 end
 
 # Define category order (categories not in this list will be sorted alphabetically at the end)
+if !isdefined(@__MODULE__, :ORDERED_CATEGORIES)
 const ORDERED_CATEGORIES = [
     Category(
         "Basic Examples",
@@ -44,6 +45,7 @@ additional patches to RxInfer.jl to work.
 """
     )
 ]
+end
 
 const ALL_EXAMPLES_CONTRIBUTING_NOTE = """
 !!! note "Contributing"
@@ -178,6 +180,7 @@ const THEME_STYLES = """
 """
 
 # Default tags for all examples
+if !isdefined(@__MODULE__, :DEFAULT_META_TAGS)
 const DEFAULT_META_TAGS = [
     "rxinfer",
     "julia",
@@ -189,14 +192,17 @@ const DEFAULT_META_TAGS = [
     "variational inference",
     "belief propagation",
 ]
+end
 
 # Directories to ignore when processing HTML files
+if !isdefined(@__MODULE__, :IGNORED_DIRECTORIES)
 const IGNORED_DIRECTORIES = [
     "_cache",
     "_assets",
     "_internal",
     ".ipynb_checkpoints"
 ]
+end
 
 # Function to generate the list of examples page
 function generate_examples_list()
@@ -212,9 +218,9 @@ function generate_examples_list()
         push!(get!(categories, folder, []), meta)
     end
 
-    # Generate markdown content
+    # Generate markdown content in-memory and write only on changes.
     output_path = joinpath(AUTOGEN_DIR, "list_of_examples.md")
-    open(output_path, "w") do io
+    io = IOBuffer()
         # Add theme styles at the top
         write(io, THEME_STYLES)
 
@@ -327,7 +333,12 @@ function generate_examples_list()
             end
         end
 
-        write(io, ALL_EXAMPLES_CONTRIBUTING_NOTE)
+    write(io, ALL_EXAMPLES_CONTRIBUTING_NOTE)
+
+    new_content = String(take!(io))
+    old_content = isfile(output_path) ? read(output_path, String) : ""
+    if new_content != old_content
+        write(output_path, new_content)
     end
 end
 


### PR DESCRIPTION
This PR addresses a bug where the LiveServer preview would keep reloading as constants were redefined. If that doesn't occur for you, maybe pass. The code logic is sound and worked effectively in my case.