### PR TITLE
Fix Gemini docs search widget: new Vertex AI Search configId

### DIFF
--- a/docs/src/assets/chat.js
+++ b/docs/src/assets/chat.js
@@ -1,10 +1,30 @@
-// In docs/src/assets/chat-widget.js
+// "Search with Gemini" widget — Google Vertex AI Search (a.k.a. Agent Search / AI Applications).
+//
+// How it works: there is NO API key in this repo. The `configId` below points to a search app
+// configured in Google Cloud Console -> AI Applications -> (app) -> Integration -> Widget tab.
+// That console page controls everything: the indexed data store (a website crawl of the
+// RxInfer docs sites), public access authorization, and the domain allowlist (examples.rxinfer.com
+// must be allowlisted there or the widget refuses to load).
+//
+// If this breaks: most likely the GCP project/app behind the configId is gone or its domain
+// allowlist changed. Re-create a "Website Content" data store + Search app in AI Applications
+// (the app MUST be Enterprise edition - website data stores require it; keep the
+// "Advanced LLM features" add-on off), grab the new configId from the Integration page,
+// and update it below.
+//
+// Current setup (June 2026): data store "rxinfer-docs-examples" (website crawl of the
+// RxInfer docs sites), Enterprise-edition search app, public access, domain allowlist
+// includes examples.rxinfer.com. Shared with the RxInfer.jl docs (same configId there).
 document.addEventListener('DOMContentLoaded', function() {
     // Create and append the search widget
-    const searchWidget = document.createElement('gen-search-widget');
-    searchWidget.setAttribute('configId', '1bea2ada-cbee-4d63-9154-6e68f77e8aa0');
-    searchWidget.setAttribute('triggerId', 'searchWidgetTrigger');
-    document.body.appendChild(searchWidget);
+    try {
+        const searchWidget = document.createElement('gen-search-widget');
+        searchWidget.setAttribute('configId', '25c1f1ae-0f92-4c7c-945d-5aaabdc5c7f1');
+        searchWidget.setAttribute('triggerId', 'searchWidgetTrigger');
+        document.body.appendChild(searchWidget);
+    } catch (e) {
+        console.warn('Gemini search widget failed to initialize:', e);
+    }
 
     // Find the docs search query element
     const docsSearchQuery = document.getElementById('documenter-search-query');
@@ -15,7 +35,7 @@ document.addEventListener('DOMContentLoaded', function() {
             width: 14.4rem;
         `;
         aiSearchContainer.classList.add('mx-auto');
-        
+
         // Add "or" text
         const orText = document.createElement('div');
         orText.textContent = 'or';
@@ -24,7 +44,7 @@ document.addEventListener('DOMContentLoaded', function() {
             color: #666;
             font-size: 0.9em;
         `;
-        
+
         aiSearchContainer.appendChild(orText);
 
         // Create and append the trigger input
@@ -32,15 +52,18 @@ document.addEventListener('DOMContentLoaded', function() {
         searchTrigger.setAttribute('placeholder', 'Search with Gemini');
         searchTrigger.setAttribute('id', 'searchWidgetTrigger');
         searchTrigger.classList.add('docs-search-query','input','is-rounded','is-small','is-clickable','my-2','py-1','px-2');
-        
+
         aiSearchContainer.appendChild(searchTrigger);
         docsSearchQuery.parentNode.insertBefore(aiSearchContainer, docsSearchQuery.nextSibling);
 
-        
+
     }
 
     // Load the Google Gen AI SDK
     const script = document.createElement('script');
     script.src = 'https://cloud.google.com/ai/gen-app-builder/client?hl=en_US';
+    script.onerror = function() {
+        console.warn('Gemini search widget: failed to load the Google Gen App Builder SDK');
+    };
     document.head.appendChild(script);
 });


### PR DESCRIPTION
## Summary

Companion to ReactiveBayes/RxInfer.jl#668. The \"Search with Gemini\" helper broke because the Google Cloud project backing the old Vertex AI Search `configId` no longer exists.

- Point the `<gen-search-widget>` at the new Vertex AI Search (AI Applications) app (`configId 25c1f1ae-0f92-4c7c-945d-5aaabdc5c7f1`, same app as the RxInfer.jl docs; `examples.rxinfer.com` is on the domain allowlist)
- Document the setup in `chat.js`: no API key in the repo — everything is configured in GCP Console → AI Applications → Integration; website data stores require an **Enterprise-edition** search app
- Add `try/catch` + `script.onerror` so failures surface as `console.warn` instead of vanishing

## Test plan

- [ ] Build docs and confirm the "Search with Gemini" input appears under the native search box
- [ ] After deploy, run a query on examples.rxinfer.com and confirm the widget returns results (the freshly created index may take a few hours to fill)

🤖 Generated with [Claude Code](https://claude.com/claude-code)